### PR TITLE
Update README installation instructions for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # napari-cryoet-data-portal
 
-[![tests](https://github.com/chanzuckerberg/napari-cryoet-data-portal/workflows/tests/badge.svg)](https://github.com/chanzuckerberg/napari-cryoet-data-portal/actions)
-[![codecov](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal/branch/main/graph/badge.svg)](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal)
+[![MIT License](https://img.shields.io/pypi/l/napari-cryoet-data-portal.svg?color=green)](https://github.com/chanzuckerberg/napari-cryoet-data-portal/raw/main/LICENSE)
+[![Python package index](https://img.shields.io/pypi/v/napari-cryoet-data-portal.svg?color=green)](https://pypi.org/project/napari-cryoet-data-portal)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/napari-cryoet-data-portal.svg?color=green)](https://python.org)
+[![Test status](https://github.com/chanzuckerberg/napari-cryoet-data-portal/workflows/tests/badge.svg)](https://github.com/chanzuckerberg/napari-cryoet-data-portal/actions)
+[![Code coverage](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal/branch/main/graph/badge.svg)](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal)
+[![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-cryoet-data-portal)](https://napari-hub.org/plugins/napari-cryoet-data-portal)
 
 List and open tomograms from the [CZ Imaging Institute's CryoET Data Portal] in [napari].
 

--- a/README.md
+++ b/README.md
@@ -3,15 +3,22 @@
 [![tests](https://github.com/chanzuckerberg/napari-cryoet-data-portal/workflows/tests/badge.svg)](https://github.com/chanzuckerberg/napari-cryoet-data-portal/actions)
 [![codecov](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal/branch/main/graph/badge.svg)](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal)
 
-List and open tomograms from the [CZII CryoET Data Portal] in [napari].
+List and open tomograms from the [CZ Imaging Institute's CryoET Data Portal] in [napari].
 
 https://github.com/chanzuckerberg/napari-cryoet-data-portal/assets/2608297/6ccbd314-fd2b-40aa-abeb-dd1afe2a61e2
 
 ## Installation
 
-You can install the latest development version using [pip]:
+You can install the latest stable version using [pip]:
 
-    pip install git+https://github.com/chanzuckerberg/napari-cryoet-data-portal.git
+    pip install napari-cryoet-data-portal
+
+You will also need to install napari separately as a Python package in the same environment.
+One way to do that with Qt included is to run:
+
+    pip install "napari[all]"
+
+but more generally you should follow the [latest napari installation instructions].
 
 ## Usage
 
@@ -53,6 +60,10 @@ These operations can also be cancelled by clicking the *Cancel* button.
 This is still in early development, but contributions and ideas are welcome!
 Don't hesitate to [open an issue] or [open a pull request] to help improve this plugin.
 
+To setup a development environment, fork this repository, clone your fork, change into its top level directory and run:
+
+    pip install -e ".[testing]"
+
 This project adheres to the [Contributor Covenant code of conduct].
 By participating, you are expected to uphold this code.
 Please report unacceptable behavior to opensource@chanzuckerberg.com.
@@ -82,3 +93,4 @@ This plugin was generated with [Cookiecutter] using [@napari]'s [cookiecutter-na
 [Contributor Covenant code of conduct]: https://github.com/chanzuckerberg/.github/tree/master/CODE_OF_CONDUCT.md
 [open an issue]: https://github.com/chanzuckerberg/napari-cryoet-data-portal/issues
 [open a pull request]: https://github.com/chanzuckerberg/napari-cryoet-data-portal/pulls
+[latest napari installation instructions]: https://napari.org/stable/tutorials/fundamentals/installation.html#install-as-python-package-recommended

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 List and open tomograms from the CZ Imaging Institute's [CryoET Data Portal] in [napari].
 
-<video title='Preview of the plugin' src='https://github.com/chanzuckerberg/napari-cryoet-data-portal/assets/2608297/6ccbd314-fd2b-40aa-abeb-dd1afe2a61e2' poster='https://github.com/andy-sweet/napari-cryoet-data-portal/assets/2608297/f8470b1c-2e91-4730-924c-95dc7c6256bb' controls></video>
+<video title='Preview of the plugin' src='https://github.com/chanzuckerberg/napari-cryoet-data-portal/assets/2608297/6ccbd314-fd2b-40aa-abeb-dd1afe2a61e2' controls></video>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![Code coverage](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal/branch/main/graph/badge.svg)](https://codecov.io/gh/chanzuckerberg/napari-cryoet-data-portal)
 [![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-cryoet-data-portal)](https://napari-hub.org/plugins/napari-cryoet-data-portal)
 
-List and open tomograms from the [CZ Imaging Institute's CryoET Data Portal] in [napari].
+List and open tomograms from the CZ Imaging Institute's [CryoET Data Portal] in [napari].
 
-https://github.com/chanzuckerberg/napari-cryoet-data-portal/assets/2608297/6ccbd314-fd2b-40aa-abeb-dd1afe2a61e2
+<video title='Preview of the plugin' src='https://github.com/chanzuckerberg/napari-cryoet-data-portal/assets/2608297/6ccbd314-fd2b-40aa-abeb-dd1afe2a61e2' poster='https://github.com/andy-sweet/napari-cryoet-data-portal/assets/2608297/f8470b1c-2e91-4730-924c-95dc7c6256bb' controls></video>
 
 ## Installation
 
@@ -87,7 +87,7 @@ This plugin was generated with [Cookiecutter] using [@napari]'s [cookiecutter-na
 
 [napari]: https://github.com/napari/napari
 [@napari]: https://github.com/napari
-[CZII CryoET Data Portal]: https://chanzuckerberg.github.io/cryoet-data-portal
+[CryoET Data Portal]: https://chanzuckerberg.github.io/cryoet-data-portal
 [pip]: https://pypi.org/project/pip/
 [Cookiecutter]: https://github.com/audreyr/cookiecutter
 [cookiecutter-napari-plugin]: https://github.com/napari/cookiecutter-napari-plugin

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 List and open tomograms from the CZ Imaging Institute's [CryoET Data Portal] in [napari].
 
-<video title='Preview of the plugin' src='https://github.com/chanzuckerberg/napari-cryoet-data-portal/assets/2608297/6ccbd314-fd2b-40aa-abeb-dd1afe2a61e2' controls></video>
+![Plugin showing tomogram TS_026](https://github.com/andy-sweet/napari-cryoet-data-portal/assets/2608297/f8470b1c-2e91-4730-924c-95dc7c6256bb)
 
 ## Installation
 
@@ -25,6 +25,10 @@ One way to do that with Qt included is to run:
 but more generally you should follow the [latest napari installation instructions].
 
 ## Usage
+
+See the following video for a demonstration of basic usage of the plugin.
+
+https://github.com/chanzuckerberg/napari-cryoet-data-portal/assets/2608297/6ccbd314-fd2b-40aa-abeb-dd1afe2a61e2
 
 Click the *Connect* button to establish a connection to the data portal.
 


### PR DESCRIPTION
This updates the README's installation instructions to install from PyPI instead of GitHub. It also makes some updates to the content in the README so that it should render better on GitHub and PyPI.