### PR TITLE
Add offset to account separated scales

### DIFF
--- a/src/napari_cryoet_data_portal/_open_widget.py
+++ b/src/napari_cryoet_data_portal/_open_widget.py
@@ -33,6 +33,16 @@ class Resolution:
     indices: Tuple[int, ...]
     scale: float
 
+    @property
+    def offset(self) -> float:
+        """The offset due to a larger first pixel for lower resolutions.
+
+        When visualized in napari, this ensures that the different multi-scale
+        layers opened separately share the same visual extent in the canvas that
+        starts at (-0.5, -0.5).
+        """
+        return (self.scale - 1) / 2
+
 
 MULTI_RESOLUTION = Resolution(name="Multi", indices=(0, 1, 2), scale=1)
 HIGH_RESOLUTION = Resolution(name="High", indices=(0,), scale=1)
@@ -132,6 +142,10 @@ class OpenWidget(QGroupBox):
             image_data = np.asarray(image_data)
         image_attrs["scale"] = tuple(
             resolution.scale * s for s in image_attrs["scale"]
+        )
+        image_translate = image_attrs.get("translate", (0,) * len(image_attrs["scale"]))
+        image_attrs["translate"] = tuple(
+            resolution.offset + t for t in image_translate
         )
         yield image_data, image_attrs, "image"
 

--- a/src/napari_cryoet_data_portal/_open_widget.py
+++ b/src/napari_cryoet_data_portal/_open_widget.py
@@ -39,7 +39,7 @@ class Resolution:
 
         When visualized in napari, this ensures that the different multi-scale
         layers opened separately share the same visual extent in the canvas that
-        starts at (-0.5, -0.5).
+        starts at (-0.5, -0.5, -0.5).
         """
         return (self.scale - 1) / 2
 


### PR DESCRIPTION
Given the way the tomograms were downsampled, the visualized extent of the different multi-scale level volumes should match. Also given napari's preference, the visualized extent of the volumes should start at (-0.5, -0.5, -0.5).

This PR adds an extra offset via `Layer.translate` to ensure that both these things happen. The related bug explains why the annotations previously looked slightly offset at the lower resolution scales.

Thanks to @kephale for helping to catch and debug this!