### PR TITLE
Basic filter by dataset and spacing IDs

### DIFF
--- a/src/napari_cryoet_data_portal/_filter.py
+++ b/src/napari_cryoet_data_portal/_filter.py
@@ -1,39 +1,76 @@
 from __future__ import annotations
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Tuple, Type, Union
+from typing import TYPE_CHECKING, Dict, Generator, List, Protocol, Tuple, Type, Union
 
-from cryoet_data_portal import Dataset, Tomogram, TomogramVoxelSpacing
-
-from napari_cryoet_data_portal._logging import logger
+from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
 
 # Guard with type checking because this is a private import.
 if TYPE_CHECKING:
-    from cryoet_data_portal._gql_base import GQLExpression
+    from cryoet_data_portal._gql_base import GQLExpression, GQLField
+
+
+class Filter(Protocol):
+    def load(self, client: Client) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
+        """Load the datasets and tomograms that match this filter."""
 
 
 @dataclass(frozen=True)
-class Filter:
-    type: Union[Type[Dataset], Type[Tomogram], Type[TomogramVoxelSpacing]] = Dataset
+class DatasetFilter:
     ids: Tuple[int, ...] = ()
 
-    def to_gql(self) -> Tuple["GQLExpression", ...]:
-        return () if len(self.ids) == 0 else (self.type.id._in(self.ids),)
+    def load(self, client: Client) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
+        gql_filters = _ids_to_gql(Dataset.id, self.ids)
+        for dataset in Dataset.find(client, gql_filters):
+            tomograms: List[Tomogram] = []
+            for run in dataset.runs:
+                for spacing in run.tomogram_voxel_spacings:
+                    tomograms.extend(spacing.tomograms)
+            yield dataset, tomograms
 
-    @classmethod
-    def from_csv(cls, type, *, csv: str) -> Filter:
-        return cls(
-            type=type,
-            ids=_csv_to_ids(csv),
-        )
 
-
-def _csv_to_ids(csv: str) -> Tuple[int, ...]:
+@dataclass(frozen=True)
+class SpacingFilter:
     ids: Tuple[int, ...] = ()
-    csv = csv.strip()
-    if len(csv) > 0:
-        try:
-            names = csv.split(",")
-            ids = tuple(int(name) for name in names)
-        except ValueError as e:
-            raise ValueError(f"Failed to parse numeric IDs: {csv}") from e
-    return ids
+
+    def load(self, client: Client) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
+        datasets: Dict[int, Dataset] = {}
+        tomograms: Dict[int, List[Tomogram]] = defaultdict(list)
+        gql_filters = _ids_to_gql(TomogramVoxelSpacing.id, self.ids)
+        for spacing in TomogramVoxelSpacing.find(client, gql_filters):
+            dataset = spacing.run.dataset
+            datasets[dataset.id] = dataset
+            tomograms[dataset.id].extend(spacing.tomograms)
+        for i in datasets:
+            yield datasets[i], tomograms[i]
+
+
+@dataclass(frozen=True)
+class TomogramFilter:
+    ids: Tuple[int, ...] = ()
+
+    def load(self, client: Client) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
+        datasets: Dict[int, Dataset] = {}
+        tomograms: Dict[int, List[Tomogram]] = defaultdict(list)
+        gql_filters = _ids_to_gql(Tomogram.id, self.ids)
+        for tomogram in Tomogram.find(client, gql_filters):
+            dataset = tomogram.tomogram_voxel_spacing.run.dataset
+            datasets[dataset.id] = dataset
+            tomograms[dataset.id].append(tomogram)
+        for i in datasets:
+            yield datasets[i], tomograms[i]
+
+
+def make_filter(type: Union[Type[Dataset], Type[TomogramVoxelSpacing], Type[Tomogram]], ids: Tuple[int, ...]) -> Filter:
+    if type is Dataset:
+        return DatasetFilter(ids=ids)
+    elif type is TomogramVoxelSpacing:
+        return SpacingFilter(ids=ids)
+    elif type is Tomogram:
+        return TomogramFilter(ids=ids)
+    else:
+        raise RuntimeError("Entity type not supported: %s", type)
+
+
+def _ids_to_gql(id_field: "GQLField", ids: Tuple[int, ...]) -> Tuple["GQLExpression", ...]:
+    return () if len(ids) == 0 else (id_field._in(ids),)

--- a/src/napari_cryoet_data_portal/_filter.py
+++ b/src/napari_cryoet_data_portal/_filter.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Dict, Generator, List, Protocol, Tuple, Type, Union
 
-from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
+from cryoet_data_portal import Client, Dataset, Run, Tomogram, TomogramVoxelSpacing
 
 # Guard with type checking because this is a private import.
 if TYPE_CHECKING:
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 class Filter(Protocol):
     def load(self, client: Client) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
         """Load the datasets and tomograms that match this filter."""
+        ...
 
 
 @dataclass(frozen=True)
@@ -27,6 +28,23 @@ class DatasetFilter:
                 for spacing in run.tomogram_voxel_spacings:
                     tomograms.extend(spacing.tomograms)
             yield dataset, tomograms
+
+
+@dataclass(frozen=True)
+class RunFilter:
+    ids: Tuple[int, ...] = ()
+
+    def load(self, client: Client) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
+        datasets: Dict[int, Dataset] = {}
+        tomograms: Dict[int, List[Tomogram]] = defaultdict(list)
+        gql_filters = _ids_to_gql(Run.id, self.ids)
+        for run in Run.find(client, gql_filters):
+            dataset = run.dataset
+            datasets[dataset.id] = dataset
+            for spacing in run.tomogram_voxel_spacings:
+                tomograms[dataset.id].extend(spacing.tomograms)
+        for i in datasets:
+            yield datasets[i], tomograms[i]
 
 
 @dataclass(frozen=True)
@@ -61,9 +79,11 @@ class TomogramFilter:
             yield datasets[i], tomograms[i]
 
 
-def make_filter(type: Union[Type[Dataset], Type[TomogramVoxelSpacing], Type[Tomogram]], ids: Tuple[int, ...]) -> Filter:
+def make_filter(type: Union[Type[Dataset], Type[Run], Type[TomogramVoxelSpacing], Type[Tomogram]], ids: Tuple[int, ...]) -> Filter:
     if type is Dataset:
         return DatasetFilter(ids=ids)
+    elif type is Run:
+        return RunFilter(ids=ids)
     elif type is TomogramVoxelSpacing:
         return SpacingFilter(ids=ids)
     elif type is Tomogram:

--- a/src/napari_cryoet_data_portal/_filter.py
+++ b/src/napari_cryoet_data_portal/_filter.py
@@ -1,20 +1,29 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple, Type, Union
+
+from cryoet_data_portal import Dataset, TomogramVoxelSpacing
 
 from napari_cryoet_data_portal._logging import logger
+
+# Guard with type checking because this is a private import.
+if TYPE_CHECKING:
+    from cryoet_data_portal._gql_base import GQLExpression
 
 
 @dataclass(frozen=True)
 class Filter:
-    dataset_ids: Tuple[int, ...] = ()
-    spacing_ids: Tuple[int, ...] = ()
+    type: Union[Type[Dataset], Type[TomogramVoxelSpacing]] = Dataset
+    ids: Tuple[int, ...] = ()
+
+    def to_gql(self) -> Tuple["GQLExpression", ...]:
+        return () if len(self.ids) == 0 else (self.type.id._in(self.ids),)
 
     @classmethod
-    def from_csv(cls, *, datasets: str, spacings: str) -> Filter:
+    def from_csv(cls, type, *, csv: str) -> Filter:
         return cls(
-            dataset_ids=_csv_to_ids(datasets),
-            spacing_ids=_csv_to_ids(spacings),
+            type=type,
+            ids=_csv_to_ids(csv),
         )
 
 

--- a/src/napari_cryoet_data_portal/_filter.py
+++ b/src/napari_cryoet_data_portal/_filter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Tuple, Type, Union
 
-from cryoet_data_portal import Dataset, TomogramVoxelSpacing
+from cryoet_data_portal import Dataset, Tomogram, TomogramVoxelSpacing
 
 from napari_cryoet_data_portal._logging import logger
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class Filter:
-    type: Union[Type[Dataset], Type[TomogramVoxelSpacing]] = Dataset
+    type: Union[Type[Dataset], Type[Tomogram], Type[TomogramVoxelSpacing]] = Dataset
     ids: Tuple[int, ...] = ()
 
     def to_gql(self) -> Tuple["GQLExpression", ...]:

--- a/src/napari_cryoet_data_portal/_filter.py
+++ b/src/napari_cryoet_data_portal/_filter.py
@@ -1,27 +1,30 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import Optional
+from typing import Tuple
 
 from napari_cryoet_data_portal._logging import logger
 
+
 @dataclass(frozen=True)
 class Filter:
-    dataset_id: Optional[int] = None
-    spacing_id: Optional[int] = None
+    dataset_ids: Tuple[int, ...] = ()
+    spacing_ids: Tuple[int, ...] = ()
 
     @classmethod
-    def from_names(cls, *, dataset: str, spacing: str) -> Filter:
+    def from_csv(cls, *, datasets: str, spacings: str) -> Filter:
         return cls(
-            dataset_id=_name_to_id(dataset),
-            spacing_id=_name_to_id(spacing),
+            dataset_ids=_csv_to_ids(datasets),
+            spacing_ids=_csv_to_ids(spacings),
         )
 
-def _name_to_id(name: str) -> Optional[int]:
-    id: Optional[int] = None
-    if len(name) > 0:
+
+def _csv_to_ids(csv: str) -> Tuple[int, ...]:
+    ids: Tuple[int, ...] = ()
+    csv = csv.strip()
+    if len(csv) > 0:
         try:
-            id = int(name)
-        except ValueError:
-            # TODO: should we just let this throw?
-            logger.error("Failed to parse ID: %s", name)
-    return id
+            names = csv.split(",")
+            ids = tuple(int(name) for name in names)
+        except ValueError as e:
+            raise ValueError(f"Failed to parse numeric IDs: {csv}") from e
+    return ids

--- a/src/napari_cryoet_data_portal/_filter.py
+++ b/src/napari_cryoet_data_portal/_filter.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+from napari_cryoet_data_portal._logging import logger
+
+@dataclass(frozen=True)
+class Filter:
+    dataset_id: Optional[int] = None
+    spacing_id: Optional[int] = None
+
+    @classmethod
+    def from_names(cls, *, dataset: str, spacing: str) -> Filter:
+        return cls(
+            dataset_id=_name_to_id(dataset),
+            spacing_id=_name_to_id(spacing),
+        )
+
+def _name_to_id(name: str) -> Optional[int]:
+    id: Optional[int] = None
+    if len(name) > 0:
+        try:
+            id = int(name)
+        except ValueError:
+            # TODO: should we just let this throw?
+            logger.error("Failed to parse ID: %s", name)
+    return id

--- a/src/napari_cryoet_data_portal/_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_listing_widget.py
@@ -48,7 +48,7 @@ class ListingWidget(QGroupBox):
         layout.addStretch(0)
         self.setLayout(layout)
 
-    def load(self, uri: str, *, filter: Filter) -> None:
+    def load(self, uri: str, *, filter: Filter = Filter()) -> None:
         """Lists the datasets and tomograms using the given portal URI."""
         logger.debug("ListingWidget.load: %s, %s", uri, filter)
         self.tree.clear()

--- a/src/napari_cryoet_data_portal/_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_listing_widget.py
@@ -89,12 +89,3 @@ class ListingWidget(QGroupBox):
             item.addChild(tomogram_item)
         _update_visible_items(item, self.tree.last_filter)
         self.tree.addTopLevelItem(item)
-
-
-def _find_tomo_by_id(client: Client, tomo_id: int) -> List[Dataset]:
-    datasets = []
-    tomos = TomogramVoxelSpacing.find(client, [TomogramVoxelSpacing.id == tomo_id])
-    for tomo in tomos:
-        datasets.append(tomo.run.dataset)
-    return datasets
-    

--- a/src/napari_cryoet_data_portal/_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_listing_widget.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from typing import Dict, Generator, List, Optional, Tuple
 
 from qtpy.QtCore import Qt
@@ -9,7 +8,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
+from cryoet_data_portal import Client, Dataset, Tomogram
 
 from napari_cryoet_data_portal._filter import DatasetFilter, Filter
 from napari_cryoet_data_portal._listing_tree_widget import ListingTreeWidget

--- a/src/napari_cryoet_data_portal/_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_listing_widget.py
@@ -8,7 +8,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from cryoet_data_portal import Client, Dataset, Tomogram
+from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
 
 from napari_cryoet_data_portal._listing_tree_widget import ListingTreeWidget
 from napari_cryoet_data_portal._logging import logger
@@ -43,27 +43,39 @@ class ListingWidget(QGroupBox):
         layout.addStretch(0)
         self.setLayout(layout)
 
-    def load(self, uri: str) -> None:
+    def load(self, uri: str, *, tomo_id: str = "") -> None:
         """Lists the datasets and tomograms using the given portal URI."""
         logger.debug("ListingWidget.load: %s", uri)
         self.tree.clear()
         self.show()
-        self._progress.submit(uri)
+        self._progress.submit(uri, tomo_id)
 
     def cancel(self) -> None:
         """Cancels the last listing."""
         logger.debug("ListingWidget.cancel")
         self._progress.cancel()
 
-    def _loadDatasets(self, uri: str) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
+    def _loadDatasets(self, uri: str, tomo_id: str) -> Generator[Tuple[Dataset, List[Tomogram]], None, None]:
         logger.debug("ListingWidget._loadDatasets: %s", uri)
         client = Client(uri)
-        for dataset in Dataset.find(client):
-            tomograms: List[Tomogram] = []
-            for run in dataset.runs:
-                for spacing in run.tomogram_voxel_spacings:
-                    tomograms.extend(spacing.tomograms)
-            yield dataset, tomograms
+        
+        tomo_id_value: Optional[int] = None
+        if len(tomo_id) > 0:
+            try:
+                tomo_id_value = int(tomo_id)
+            except ValueError:
+                logger.error("Failed to parse tomogram ID: %s", tomo_id)
+
+        if tomo_id_value is None:
+            for dataset in Dataset.find(client):
+                tomograms: List[Tomogram] = []
+                for run in dataset.runs:
+                    for spacing in run.tomogram_voxel_spacings:
+                        tomograms.extend(spacing.tomograms)
+                yield dataset, tomograms
+        else:
+            if spacing := TomogramVoxelSpacing.get_by_id(client, tomo_id_value):
+                yield spacing.run.dataset, list(spacing.tomograms)
 
     def _onDatasetLoaded(self, result: Tuple[Dataset, List[Tomogram]]) -> None:
         dataset, tomograms = result
@@ -77,3 +89,12 @@ class ListingWidget(QGroupBox):
             item.addChild(tomogram_item)
         _update_visible_items(item, self.tree.last_filter)
         self.tree.addTopLevelItem(item)
+
+
+def _find_tomo_by_id(client: Client, tomo_id: int) -> List[Dataset]:
+    datasets = []
+    tomos = TomogramVoxelSpacing.find(client, [TomogramVoxelSpacing.id == tomo_id])
+    for tomo in tomos:
+        datasets.append(tomo.run.dataset)
+    return datasets
+    

--- a/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
@@ -1,6 +1,7 @@
 import pytest
 from pytestqt.qtbot import QtBot
 
+from napari_cryoet_data_portal._filter import Filter
 from napari_cryoet_data_portal._listing_widget import ListingWidget
 from napari_cryoet_data_portal._tests._utils import (
     tree_item_children,
@@ -26,11 +27,15 @@ def test_init(qtbot: QtBot):
 
 
 def test_load_lists_data(widget: ListingWidget, qtbot: QtBot):
+    # Query two small, specific datasets to limit time spent
+    # on this test and to exercise dataset filter.
+    filter = Filter(dataset_ids=(10000, 10001))
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
-        widget.load(GRAPHQL_URI)
+        widget.load(GRAPHQL_URI, filter=filter)
     
     dataset_items = tree_top_items(widget.tree)
-    assert len(dataset_items) > 0
+    assert len(dataset_items) == 2
     tomogram_items = tree_item_children(dataset_items[0])
     assert len(tomogram_items) > 0
-    
+    tomogram_items = tree_item_children(dataset_items[1])
+    assert len(tomogram_items) > 0

--- a/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
@@ -2,7 +2,7 @@ from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
 import pytest
 from pytestqt.qtbot import QtBot
 
-from napari_cryoet_data_portal._filter import Filter
+from napari_cryoet_data_portal._filter import DatasetFilter, SpacingFilter, TomogramFilter
 from napari_cryoet_data_portal._listing_widget import ListingWidget
 from napari_cryoet_data_portal._tests._utils import (
     tree_item_children,
@@ -30,7 +30,7 @@ def test_init(qtbot: QtBot):
 def test_load_lists_data(widget: ListingWidget, qtbot: QtBot):
     # Query two small, specific datasets to limit time spent
     # on this test and to exercise dataset filter.
-    filter = Filter(type=Dataset, ids=(10000, 10001))
+    filter = DatasetFilter(ids=(10000, 10001))
 
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.load(GRAPHQL_URI, filter=filter)
@@ -47,7 +47,7 @@ def test_load_with_spacing_filter_lists_only_that_data(widget: ListingWidget, qt
     client = Client()
     spacing = client.find_one(TomogramVoxelSpacing)
     assert spacing is not None
-    filter = Filter(TomogramVoxelSpacing, ids=(spacing.id,))
+    filter = SpacingFilter(ids=(spacing.id,))
 
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.load(GRAPHQL_URI, filter=filter)
@@ -62,7 +62,7 @@ def test_load_with_tomogram_filter_lists_only_that_data(widget: ListingWidget, q
     client = Client()
     tomogram = client.find_one(Tomogram)
     assert tomogram is not None
-    filter = Filter(Tomogram, ids=(tomogram.id,))
+    filter = TomogramFilter(ids=(tomogram.id,))
 
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.load(GRAPHQL_URI, filter=filter)

--- a/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
@@ -1,6 +1,4 @@
-from typing import Optional
-
-from cryoet_data_portal import Client, TomogramVoxelSpacing
+from cryoet_data_portal import Client, Dataset, TomogramVoxelSpacing
 import pytest
 from pytestqt.qtbot import QtBot
 
@@ -32,7 +30,7 @@ def test_init(qtbot: QtBot):
 def test_load_lists_data(widget: ListingWidget, qtbot: QtBot):
     # Query two small, specific datasets to limit time spent
     # on this test and to exercise dataset filter.
-    filter = Filter(dataset_ids=(10000, 10001))
+    filter = Filter(type=Dataset, ids=(10000, 10001))
 
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.load(GRAPHQL_URI, filter=filter)
@@ -49,7 +47,7 @@ def test_load_with_spacing_filter_lists_only_that_data(widget: ListingWidget, qt
     client = Client()
     spacing = client.find_one(TomogramVoxelSpacing)
     assert spacing is not None
-    filter = Filter(spacing_ids=(spacing.id,))
+    filter = Filter(TomogramVoxelSpacing, ids=(spacing.id,))
 
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.load(GRAPHQL_URI, filter=filter)

--- a/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
@@ -1,4 +1,4 @@
-from cryoet_data_portal import Client, Dataset, TomogramVoxelSpacing
+from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
 import pytest
 from pytestqt.qtbot import QtBot
 
@@ -48,6 +48,21 @@ def test_load_with_spacing_filter_lists_only_that_data(widget: ListingWidget, qt
     spacing = client.find_one(TomogramVoxelSpacing)
     assert spacing is not None
     filter = Filter(TomogramVoxelSpacing, ids=(spacing.id,))
+
+    with qtbot.waitSignal(widget._progress.finished, timeout=60000):
+        widget.load(GRAPHQL_URI, filter=filter)
+
+    dataset_items = tree_top_items(widget.tree)
+    assert len(dataset_items) == 1
+    tomogram_items = tree_item_children(dataset_items[0])
+    assert len(tomogram_items) > 0
+
+
+def test_load_with_tomogram_filter_lists_only_that_data(widget: ListingWidget, qtbot: QtBot):
+    client = Client()
+    tomogram = client.find_one(Tomogram)
+    assert tomogram is not None
+    filter = Filter(Tomogram, ids=(tomogram.id,))
 
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.load(GRAPHQL_URI, filter=filter)

--- a/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
@@ -1,3 +1,6 @@
+from typing import Optional
+
+from cryoet_data_portal import Client, TomogramVoxelSpacing
 import pytest
 from pytestqt.qtbot import QtBot
 
@@ -30,6 +33,7 @@ def test_load_lists_data(widget: ListingWidget, qtbot: QtBot):
     # Query two small, specific datasets to limit time spent
     # on this test and to exercise dataset filter.
     filter = Filter(dataset_ids=(10000, 10001))
+
     with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.load(GRAPHQL_URI, filter=filter)
     
@@ -39,3 +43,18 @@ def test_load_lists_data(widget: ListingWidget, qtbot: QtBot):
     assert len(tomogram_items) > 0
     tomogram_items = tree_item_children(dataset_items[1])
     assert len(tomogram_items) > 0
+
+
+def test_load_with_spacing_filter_lists_only_that_data(widget: ListingWidget, qtbot: QtBot):
+    client = Client()
+    spacing = client.find_one(TomogramVoxelSpacing)
+    assert spacing is not None
+    filter = Filter(spacing_ids=(spacing.id,))
+
+    with qtbot.waitSignal(widget._progress.finished, timeout=60000):
+        widget.load(GRAPHQL_URI, filter=filter)
+
+    dataset_items = tree_top_items(widget.tree)
+    assert len(dataset_items) == 1
+    tomogram_items = tree_item_children(dataset_items[0])
+    assert len(tomogram_items) == 1

--- a/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_listing_widget.py
@@ -1,8 +1,8 @@
-from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
+from cryoet_data_portal import Client, Run, Tomogram, TomogramVoxelSpacing
 import pytest
 from pytestqt.qtbot import QtBot
 
-from napari_cryoet_data_portal._filter import DatasetFilter, SpacingFilter, TomogramFilter
+from napari_cryoet_data_portal._filter import DatasetFilter, RunFilter, SpacingFilter, TomogramFilter
 from napari_cryoet_data_portal._listing_widget import ListingWidget
 from napari_cryoet_data_portal._tests._utils import (
     tree_item_children,
@@ -40,6 +40,21 @@ def test_load_lists_data(widget: ListingWidget, qtbot: QtBot):
     tomogram_items = tree_item_children(dataset_items[0])
     assert len(tomogram_items) > 0
     tomogram_items = tree_item_children(dataset_items[1])
+    assert len(tomogram_items) > 0
+
+
+def test_load_with_run_filter_lists_only_that_data(widget: ListingWidget, qtbot: QtBot):
+    client = Client()
+    run = client.find_one(Run)
+    assert run is not None
+    filter = RunFilter(ids=(run.id,))
+
+    with qtbot.waitSignal(widget._progress.finished, timeout=60000):
+        widget.load(GRAPHQL_URI, filter=filter)
+
+    dataset_items = tree_top_items(widget.tree)
+    assert len(dataset_items) == 1
+    tomogram_items = tree_item_children(dataset_items[0])
     assert len(tomogram_items) > 0
 
 

--- a/src/napari_cryoet_data_portal/_tests/test_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_uri_widget.py
@@ -1,7 +1,7 @@
 import pytest
 from pytestqt.qtbot import QtBot
 
-from napari_cryoet_data_portal._filter import Filter
+from napari_cryoet_data_portal._filter import DatasetFilter
 from napari_cryoet_data_portal._uri_widget import GRAPHQL_URI, UriWidget
 
 
@@ -51,7 +51,7 @@ def test_click_connect_when_uri_does_not_exist(widget: UriWidget, qtbot: QtBot):
 
 
 def test_click_disconnect(widget: UriWidget, qtbot: QtBot):
-    widget._onConnected((GRAPHQL_URI, Filter()))
+    widget._onConnected((GRAPHQL_URI, DatasetFilter()))
 
     with qtbot.waitSignal(widget.disconnected):
         widget._disconnect_button.click()

--- a/src/napari_cryoet_data_portal/_tests/test_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_uri_widget.py
@@ -1,6 +1,7 @@
 import pytest
 from pytestqt.qtbot import QtBot
 
+from napari_cryoet_data_portal._filter import Filter
 from napari_cryoet_data_portal._uri_widget import GRAPHQL_URI, UriWidget
 
 
@@ -50,7 +51,7 @@ def test_click_connect_when_uri_does_not_exist(widget: UriWidget, qtbot: QtBot):
 
 
 def test_click_disconnect(widget: UriWidget, qtbot: QtBot):
-    widget._onConnected(GRAPHQL_URI)
+    widget._onConnected((GRAPHQL_URI, Filter()))
 
     with qtbot.waitSignal(widget.disconnected):
         widget._disconnect_button.click()

--- a/src/napari_cryoet_data_portal/_tests/test_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_widget.py
@@ -9,7 +9,7 @@ from pytestqt.qtbot import QtBot
 from qtpy.QtWidgets import QWidget
 
 from napari_cryoet_data_portal import DataPortalWidget
-from napari_cryoet_data_portal._filter import Filter
+from napari_cryoet_data_portal._filter import DatasetFilter
 from napari_cryoet_data_portal._uri_widget import GRAPHQL_URI
 
 
@@ -63,7 +63,7 @@ def test_listing_item_changed_to_none(widget: DataPortalWidget):
 
 def test_connected_loads_listing(widget: DataPortalWidget, mocker: MockerFixture):
     mocker.patch.object(widget._listing, 'load')
-    filter = Filter()
+    filter = DatasetFilter()
 
     widget._uri.connected.emit(GRAPHQL_URI, filter)
 

--- a/src/napari_cryoet_data_portal/_tests/test_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_widget.py
@@ -9,6 +9,7 @@ from pytestqt.qtbot import QtBot
 from qtpy.QtWidgets import QWidget
 
 from napari_cryoet_data_portal import DataPortalWidget
+from napari_cryoet_data_portal._filter import Filter
 from napari_cryoet_data_portal._uri_widget import GRAPHQL_URI
 
 
@@ -62,10 +63,11 @@ def test_listing_item_changed_to_none(widget: DataPortalWidget):
 
 def test_connected_loads_listing(widget: DataPortalWidget, mocker: MockerFixture):
     mocker.patch.object(widget._listing, 'load')
+    filter = Filter()
 
-    widget._uri.connected.emit(GRAPHQL_URI)
+    widget._uri.connected.emit(GRAPHQL_URI, filter)
 
-    widget._listing.load.assert_called_once_with(GRAPHQL_URI)
+    widget._listing.load.assert_called_once_with(GRAPHQL_URI, filter=filter)
 
 
 def test_disconnected_only_shows_uri(widget: DataPortalWidget):

--- a/src/napari_cryoet_data_portal/_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_uri_widget.py
@@ -48,7 +48,7 @@ class UriWidget(QGroupBox):
         self._filter_ids_type = QComboBox()
         self._filter_ids_type.addItem("Dataset IDs", Dataset)
         self._filter_ids_type.addItem("Run IDs", Run)
-        self._filter_ids_type.addItem("Spacing IDs", TomogramVoxelSpacing)
+        self._filter_ids_type.addItem("Voxel Spacing IDs", TomogramVoxelSpacing)
         self._filter_ids_type.addItem("Tomogram IDs", Tomogram)
         self._filter_ids_edit = QLineEdit()
         self._filter_ids_edit.setToolTip("Comma separated IDs of interest")

--- a/src/napari_cryoet_data_portal/_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_uri_widget.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
 )
 from cryoet_data_portal import Client
 
+from napari_cryoet_data_portal._filter import Filter
 from napari_cryoet_data_portal._logging import logger
 from napari_cryoet_data_portal._progress_widget import ProgressWidget
 
@@ -22,7 +23,7 @@ class UriWidget(QGroupBox):
     """Connects to a data portal with a specific URI."""
 
     # Emitted on successful connection with the URI.
-    connected = Signal(str, str)
+    connected = Signal(str, object)
     # Emitted when disconnecting from the portal.
     disconnected = Signal()
 
@@ -41,11 +42,18 @@ class UriWidget(QGroupBox):
         self._uri_edit.setCursorPosition(0)
         self._uri_edit.setPlaceholderText("Enter a URI to CryoET portal data")
         
+        dataset_layout = QHBoxLayout()
+        dataset_layout.setContentsMargins(0, 0, 0, 0)
+        self._dataset_id_edit = QLineEdit()
+        dataset_id_label = QLabel("Dataset ID")
+        dataset_id_label.setBuddy(self._dataset_id_edit)
+        dataset_layout.addWidget(dataset_id_label)
+        dataset_layout.addWidget(self._dataset_id_edit)
+        
         tomo_layout = QHBoxLayout()
         tomo_layout.setContentsMargins(0, 0, 0, 0)
         self._tomo_id_edit = QLineEdit()
-        self._tomo_id_edit
-        tomo_id_label = QLabel("Tomogram ID")
+        tomo_id_label = QLabel("Voxel spacing ID")
         tomo_id_label.setBuddy(self._tomo_id_edit)
         tomo_layout.addWidget(tomo_id_label)
         tomo_layout.addWidget(self._tomo_id_edit)
@@ -60,6 +68,7 @@ class UriWidget(QGroupBox):
         self._disconnect_button.clicked.connect(self._onDisconnectClicked)
         self._uri_edit.returnPressed.connect(self._onConnectClicked)
         self._tomo_id_edit.returnPressed.connect(self._onConnectClicked)
+        self._dataset_id_edit.returnPressed.connect(self._onConnectClicked)
 
         control_layout = QHBoxLayout()
         control_layout.setContentsMargins(0, 0, 0, 0)
@@ -69,6 +78,7 @@ class UriWidget(QGroupBox):
 
         layout = QVBoxLayout()
         layout.addLayout(control_layout)
+        layout.addLayout(dataset_layout)
         layout.addLayout(tomo_layout)
         layout.addWidget(self._progress)
 
@@ -76,9 +86,11 @@ class UriWidget(QGroupBox):
 
     def _onConnectClicked(self) -> None:
         uri = self._uri_edit.text().strip()
-        tomo_id = self._tomo_id_edit.text().strip()
-        logger.debug("UriWidget._onConnectClicked: %s, %s", uri, tomo_id)
-        self._progress.submit(uri, tomo_id)
+        dataset = self._dataset_id_edit.text().strip()
+        spacing = self._tomo_id_edit.text().strip()
+        filter = Filter.from_names(dataset=dataset, spacing=spacing)
+        logger.debug("UriWidget._onConnectClicked: %s, %s", uri, filter)
+        self._progress.submit(uri, filter)
 
     def _onDisconnectClicked(self) -> None:
         logger.debug("UriWidget._onDisconnectClicked")
@@ -86,18 +98,19 @@ class UriWidget(QGroupBox):
         self._updateVisibility(False)
         self.disconnected.emit()
 
-    def _connect(self, uri: str, tomo_id: str) -> Tuple[str, str]:
+    def _connect(self, uri: str, filter: Filter) -> Tuple[str, object]:
         _ = Client(uri)
-        return uri, tomo_id
+        return uri, filter
 
-    def _onConnected(self, result: Tuple[str, str]) -> None:
-        uri, tomo_id = result
-        logger.debug("UriWidget._onConnected: %s, %s", uri, tomo_id)
+    def _onConnected(self, result: Tuple[str, object]) -> None:
+        uri, filter = result
+        logger.debug("UriWidget._onConnected: %s, %s", uri, filter)
         self._updateVisibility(True)
-        self.connected.emit(uri, tomo_id)
+        self.connected.emit(uri, filter)
 
     def _updateVisibility(self, uri_exists: bool) -> None:
         logger.debug("UriWidget._updateVisibility: %s", uri_exists)
         self._connect_button.setVisible(not uri_exists)
+        self._dataset_id_edit.setReadOnly(uri_exists)
         self._tomo_id_edit.setReadOnly(uri_exists)
         self._disconnect_button.setVisible(uri_exists)

--- a/src/napari_cryoet_data_portal/_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_uri_widget.py
@@ -10,7 +10,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
+from cryoet_data_portal import Client, Dataset, Run, Tomogram, TomogramVoxelSpacing
 
 from napari_cryoet_data_portal._filter import Filter, make_filter
 from napari_cryoet_data_portal._logging import logger
@@ -47,6 +47,7 @@ class UriWidget(QGroupBox):
         filter_ids_layout.setContentsMargins(0, 0, 0, 0)
         self._filter_ids_type = QComboBox()
         self._filter_ids_type.addItem("Dataset IDs", Dataset)
+        self._filter_ids_type.addItem("Run IDs", Run)
         self._filter_ids_type.addItem("Voxel Spacing IDs", TomogramVoxelSpacing)
         self._filter_ids_type.addItem("Tomogram IDs", Tomogram)
         self._filter_ids_edit = QLineEdit()

--- a/src/napari_cryoet_data_portal/_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_uri_widget.py
@@ -43,9 +43,9 @@ class UriWidget(QGroupBox):
         self._uri_edit.setPlaceholderText("Enter a URI to CryoET portal data")
         
         self._dataset_ids_edit, dataset_widget = _make_labeled_edit(
-            "Dataset IDs", "Comma separated dataset IDs query")
+            "Dataset IDs", "Comma separated dataset IDs of interest")
         self._spacing_ids_edit, spacing_widget = _make_labeled_edit(
-            "Voxel Spacing IDs", "Comma separated voxel spacing IDs to query")
+            "Voxel Spacing IDs", "Comma separated voxel spacing IDs of interest")
 
         self._progress: ProgressWidget = ProgressWidget(
             work=self._connect,

--- a/src/napari_cryoet_data_portal/_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_uri_widget.py
@@ -11,7 +11,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from cryoet_data_portal import Client, Dataset, TomogramVoxelSpacing
+from cryoet_data_portal import Client, Dataset, Tomogram, TomogramVoxelSpacing
 
 from napari_cryoet_data_portal._filter import Filter
 from napari_cryoet_data_portal._logging import logger
@@ -49,6 +49,7 @@ class UriWidget(QGroupBox):
         self._filter_ids_type = QComboBox()
         self._filter_ids_type.addItem("Dataset IDs", Dataset)
         self._filter_ids_type.addItem("Voxel Spacing IDs", TomogramVoxelSpacing)
+        self._filter_ids_type.addItem("Tomogram IDs", Tomogram)
         self._filter_ids_edit = QLineEdit()
         self._filter_ids_edit.setToolTip("Comma separated IDs of interest")
         filter_ids_layout.addWidget(self._filter_ids_type)

--- a/src/napari_cryoet_data_portal/_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_uri_widget.py
@@ -48,7 +48,7 @@ class UriWidget(QGroupBox):
         self._filter_ids_type = QComboBox()
         self._filter_ids_type.addItem("Dataset IDs", Dataset)
         self._filter_ids_type.addItem("Run IDs", Run)
-        self._filter_ids_type.addItem("Voxel Spacing IDs", TomogramVoxelSpacing)
+        self._filter_ids_type.addItem("Spacing IDs", TomogramVoxelSpacing)
         self._filter_ids_type.addItem("Tomogram IDs", Tomogram)
         self._filter_ids_edit = QLineEdit()
         self._filter_ids_edit.setToolTip("Comma separated IDs of interest")

--- a/src/napari_cryoet_data_portal/_uri_widget.py
+++ b/src/napari_cryoet_data_portal/_uri_widget.py
@@ -98,11 +98,11 @@ class UriWidget(QGroupBox):
         self._updateVisibility(False)
         self.disconnected.emit()
 
-    def _connect(self, uri: str, filter: Filter) -> Tuple[str, object]:
+    def _connect(self, uri: str, filter: Filter) -> Tuple[str, Filter]:
         _ = Client(uri)
         return uri, filter
 
-    def _onConnected(self, result: Tuple[str, object]) -> None:
+    def _onConnected(self, result: Tuple[str, Filter]) -> None:
         uri, filter = result
         logger.debug("UriWidget._onConnected: %s, %s", uri, filter)
         self._updateVisibility(True)

--- a/src/napari_cryoet_data_portal/_widget.py
+++ b/src/napari_cryoet_data_portal/_widget.py
@@ -69,6 +69,7 @@ class DataPortalWidget(QWidget):
     def _onUriConnected(self, uri: str, filter: object) -> None:
         logger.debug("DataPortalWidget._onUriConnected")
         self._open.setUri(uri)
+        # TODO: define custom type for Qt signal.
         self._listing.load(uri, filter=cast(Filter, filter))
 
     def _onUriDisconnected(self) -> None:

--- a/src/napari_cryoet_data_portal/_widget.py
+++ b/src/napari_cryoet_data_portal/_widget.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, cast
+from typing import TYPE_CHECKING, Optional
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
@@ -8,7 +8,6 @@ from qtpy.QtWidgets import (
 )
 from cryoet_data_portal import Tomogram
 
-from napari_cryoet_data_portal._filter import Filter
 from napari_cryoet_data_portal._listing_widget import ListingWidget
 from napari_cryoet_data_portal._logging import logger
 from napari_cryoet_data_portal._metadata_widget import MetadataWidget
@@ -69,8 +68,7 @@ class DataPortalWidget(QWidget):
     def _onUriConnected(self, uri: str, filter: object) -> None:
         logger.debug("DataPortalWidget._onUriConnected")
         self._open.setUri(uri)
-        # TODO: define custom type for Qt signal.
-        self._listing.load(uri, filter=cast(Filter, filter))
+        self._listing.load(uri, filter=filter)
 
     def _onUriDisconnected(self) -> None:
         logger.debug("DataPortalWidget._onUriDisconnected")

--- a/src/napari_cryoet_data_portal/_widget.py
+++ b/src/napari_cryoet_data_portal/_widget.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, cast
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
@@ -6,8 +6,9 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from cryoet_data_portal import Client, Tomogram
+from cryoet_data_portal import Tomogram
 
+from napari_cryoet_data_portal._filter import Filter
 from napari_cryoet_data_portal._listing_widget import ListingWidget
 from napari_cryoet_data_portal._logging import logger
 from napari_cryoet_data_portal._metadata_widget import MetadataWidget
@@ -65,10 +66,10 @@ class DataPortalWidget(QWidget):
 
         self.setLayout(layout)
 
-    def _onUriConnected(self, uri: str, tomo_id: str) -> None:
+    def _onUriConnected(self, uri: str, filter: object) -> None:
         logger.debug("DataPortalWidget._onUriConnected")
         self._open.setUri(uri)
-        self._listing.load(uri, tomo_id=tomo_id)
+        self._listing.load(uri, filter=cast(Filter, filter))
 
     def _onUriDisconnected(self) -> None:
         logger.debug("DataPortalWidget._onUriDisconnected")

--- a/src/napari_cryoet_data_portal/_widget.py
+++ b/src/napari_cryoet_data_portal/_widget.py
@@ -65,10 +65,10 @@ class DataPortalWidget(QWidget):
 
         self.setLayout(layout)
 
-    def _onUriConnected(self, uri: str) -> None:
+    def _onUriConnected(self, uri: str, tomo_id: str) -> None:
         logger.debug("DataPortalWidget._onUriConnected")
         self._open.setUri(uri)
-        self._listing.load(uri)
+        self._listing.load(uri, tomo_id=tomo_id)
 
     def _onUriDisconnected(self) -> None:
         logger.debug("DataPortalWidget._onUriDisconnected")


### PR DESCRIPTION
This adds some widgets to the portal connection/URI sub-widget that allows users to search for a specific datasets and tomograms using known IDs.

It also add tests that use some of this filtering behavior as a way to exercise the behavior and to better bound test time against the real GraphQL backend.

Closes #12