### PR TITLE
Add a check-box to control if existing layers are cleared

### DIFF
--- a/src/napari_cryoet_data_portal/_open_widget.py
+++ b/src/napari_cryoet_data_portal/_open_widget.py
@@ -5,6 +5,7 @@ import numpy as np
 from npe2.types import FullLayerData
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
+    QCheckBox,
     QComboBox,
     QGroupBox,
     QHBoxLayout,
@@ -94,8 +95,12 @@ class OpenWidget(QGroupBox):
         control_layout.addWidget(self.resolution_label)
         control_layout.addWidget(self.resolution)
 
+        self._clear_existing_layers = QCheckBox("Clear existing layers")
+        self._clear_existing_layers.setChecked(True)
+
         layout = QVBoxLayout()
         layout.addLayout(control_layout)
+        layout.addWidget(self._clear_existing_layers)
         layout.addWidget(self._progress)
         self.setLayout(layout)
 
@@ -118,7 +123,8 @@ class OpenWidget(QGroupBox):
         """Loads the current tomogram at the current resolution."""
         resolution = self.resolution.currentData()
         logger.debug("OpenWidget.load: %s", self._tomogram, resolution)
-        self._viewer.layers.clear()
+        if self._clear_existing_layers.isChecked():
+            self._viewer.layers.clear()
         self._progress.submit(self._tomogram, resolution)
 
     def cancel(self) -> None:

--- a/src/napari_cryoet_data_portal/_tests/test_open_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_open_widget.py
@@ -3,6 +3,7 @@ import pytest
 from pytestqt.qtbot import QtBot
 
 from cryoet_data_portal import Tomogram
+from napari.layers import Points
 
 from napari_cryoet_data_portal._open_widget import OpenWidget
 
@@ -28,9 +29,24 @@ def test_init(viewer_model: ViewerModel, qtbot: QtBot):
 
 def test_set_tomogram_adds_layers_to_viewer(widget: OpenWidget, tomogram: Tomogram, qtbot: QtBot):
     assert len(widget._viewer.layers) == 0
+    widget._viewer.layers.append(Points())
+    assert len(widget._viewer.layers) == 1
+    assert widget._clear_existing_layers.isChecked()
     
     with qtbot.waitSignal(widget._progress.finished, timeout=30000):
         widget.setTomogram(tomogram)
     
     assert len(widget._viewer.layers) == 3
+
+
+def test_set_tomogram_adds_layers_to_viewer_without_clearing_existing(widget: OpenWidget, tomogram: Tomogram, qtbot: QtBot):
+    assert len(widget._viewer.layers) == 0
+    widget._viewer.layers.append(Points())
+    assert len(widget._viewer.layers) == 1
+    widget._clear_existing_layers.setChecked(False)
+
+    with qtbot.waitSignal(widget._progress.finished, timeout=30000):
+        widget.setTomogram(tomogram)
+
+    assert len(widget._viewer.layers) == 4
     


### PR DESCRIPTION
This adds a checkbox to the open panel that controls if the existing layers are cleared before opening the next set of tomogram + annotations. If it is checked, the layers are cleared. This takes effect if the tomogram is opened by clicking on a tree item or by clicking the open button. By default it is checked, so existing layers are cleared, as the original purpose of this plugin was for browsing.

The was added to accommodate more complex workflows beyond simple browsing (e.g. comparing point annotations with a automatic dense segmentation from elsewhere).
