### PR TITLE
Update usage of GraphQL client to match new schema

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    cryoet_data_portal
+    cryoet_data_portal>=2
     fsspec[http,s3]
     npe2
     numpy

--- a/src/napari_cryoet_data_portal/_open_widget.py
+++ b/src/napari_cryoet_data_portal/_open_widget.py
@@ -165,7 +165,15 @@ class OpenWidget(QGroupBox):
         )
 
         for annotation in annotations:
-            yield read_annotation(annotation, tomogram=tomogram)
+            point_paths = tuple(
+                f.https_path
+                for f in annotation.files
+                if f.shape_type == "Point"
+            )
+            if len(point_paths) > 0:
+                yield read_annotation(annotation, tomogram=tomogram)
+            else:
+                logger.warn("Found no points annotations. Skipping.")
 
     def _onLayerLoaded(self, layer_data: FullLayerData) -> None:
         logger.debug("OpenWidget._onLayerLoaded")

--- a/src/napari_cryoet_data_portal/_sample_data.py
+++ b/src/napari_cryoet_data_portal/_sample_data.py
@@ -23,7 +23,7 @@ def tomogram_10000_ts_027() -> List[FullLayerData]:
 def _read_tomogram_from_10000(name: str) -> List[FullLayerData]:
     client = Client()
     
-    tomogram_spacing_url = f"https://files.cryoetdataportal.cziscience.com/10000/{name}/Tomograms/VoxelSpacing13.48/"
+    tomogram_spacing_url = f"https://files.cryoetdataportal.cziscience.com/10000/{name}/Tomograms/VoxelSpacing13.480/"
     tomogram_spacing = next(TomogramVoxelSpacing.find(client, [TomogramVoxelSpacing.https_prefix == tomogram_spacing_url]))
 
     tomogram: Tomogram = next(tomogram_spacing.tomograms)

--- a/src/napari_cryoet_data_portal/_tests/conftest.py
+++ b/src/napari_cryoet_data_portal/_tests/conftest.py
@@ -15,4 +15,4 @@ def dataset(client: Client) -> Dataset:
 
 @pytest.fixture()
 def tomogram(client: Client) -> Tomogram:
-    return next(Tomogram.find(client, [Tomogram.name == 'TS_026']))
+    return next(Tomogram.find(client, [Tomogram.name == 'TS_026', Tomogram.https_omezarr_dir.like("%13.480%")]))

--- a/src/napari_cryoet_data_portal/_tests/test_reader.py
+++ b/src/napari_cryoet_data_portal/_tests/test_reader.py
@@ -2,7 +2,6 @@ from typing import Callable
 
 from napari import Viewer
 from napari.layers import Points
-from cryoet_data_portal import Annotation, Client
 
 from napari_cryoet_data_portal import (
     read_points_annotations_ndjson,
@@ -10,8 +9,8 @@ from napari_cryoet_data_portal import (
 )
 
 CLOUDFRONT_URI = "https://files.cryoetdataportal.cziscience.com"
-TOMOGRAM_DIR = f"{CLOUDFRONT_URI}/10000/TS_026/Tomograms/VoxelSpacing13.48"
-ANNOTATION_FILE = f"{TOMOGRAM_DIR}/Annotations/sara_goetz-ribosome-1.0.ndjson"
+TOMOGRAM_DIR = f"{CLOUDFRONT_URI}/10000/TS_026/Tomograms/VoxelSpacing13.480"
+ANNOTATION_FILE = f"{TOMOGRAM_DIR}/Annotations/101-cytosolic_ribosome-1.0_point.ndjson"
 
 
 def test_read_tomogram_ome_zarr():


### PR DESCRIPTION
This bumps the minimum required version of `cryoet-data-portal` to v2 that includes changes to the underlying GraphQL schema.

It also changes the readers and widgets to adapt to the corresponding API changes, so that tomograms and points annotations are read correctly when they are available.