### PR TITLE
Use image preview list to show tomograms

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     ndjson
     qtpy
     superqt
+    scikit-image
 
 python_requires = >=3.8
 include_package_data = True

--- a/src/napari_cryoet_data_portal/_preview_list_widget.py
+++ b/src/napari_cryoet_data_portal/_preview_list_widget.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from qtpy.QtCore import QRegularExpression, QSize
+from qtpy.QtWidgets import (
+    QListWidget,
+    QListWidgetItem,
+    QWidget,
+)
+
+from napari_cryoet_data_portal._logging import logger
+
+
+class PreviewListWidget(QListWidget):
+    """A filterable list of icons."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        self._last_filter: QRegularExpression = QRegularExpression("")
+
+        self.setViewMode(QListWidget.ViewMode.IconMode)
+        self.setSelectionMode(QListWidget.SelectionMode.SingleSelection)
+        self.setFlow(QListWidget.Flow.LeftToRight)
+        self.setDragEnabled(False)
+        self.setAcceptDrops(False)
+        self.setIconSize(QSize(64, 64))
+
+    def addItem(self, item: QListWidgetItem) -> None:
+        logger.debug("PreviewListWidget.addItem: %s", item)
+        _update_visible_item(item, self._last_filter)
+        super().addItem(item)
+
+    def updateVisibleItems(self, pattern: str) -> None:
+        logger.debug("PreviewListWidget.updateVisibleItems: %s", pattern)
+        self._last_filter = QRegularExpression(pattern)
+        for i in range(self.count()):
+            item = self.item(i)
+            _update_visible_item(item, self._last_filter)
+
+
+def _update_visible_item(
+    item: QListWidgetItem, expression: QRegularExpression
+) -> None:
+    text = item.text()
+    visible = expression.match(text).hasMatch()
+    item.setHidden(not visible)

--- a/src/napari_cryoet_data_portal/_preview_widget.py
+++ b/src/napari_cryoet_data_portal/_preview_widget.py
@@ -26,7 +26,7 @@ class PreviewWidget(QGroupBox):
 
         self._uri: Optional[str] = None
 
-        self.setTitle("Preview")
+        self.setTitle("Tomograms")
         self.list = PreviewListWidget()
         self._progress = ProgressWidget(
             work=self._loadTomograms,

--- a/src/napari_cryoet_data_portal/_preview_widget.py
+++ b/src/napari_cryoet_data_portal/_preview_widget.py
@@ -1,0 +1,98 @@
+from typing import Generator, Optional, Tuple
+
+import numpy as np
+from qtpy.QtCore import QSize, Qt
+from qtpy.QtGui import QBitmap, QIcon
+from qtpy.QtWidgets import (
+    QGroupBox,
+    QListWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from cryoet_data_portal import Client, Dataset, Run, Tomogram
+
+from napari_cryoet_data_portal._logging import logger
+from napari_cryoet_data_portal._preview_list_widget import PreviewListWidget
+from napari_cryoet_data_portal._progress_widget import ProgressWidget
+from napari_cryoet_data_portal._reader import read_tomogram
+
+
+class PreviewWidget(QGroupBox):
+    """Previews tomograms in a dataset as a list of thumbnail images."""
+
+    def __init__(self, parent: Optional[QWidget] = None) -> None:
+        super().__init__(parent)
+
+        self._uri: Optional[str] = None
+
+        self.setTitle("Preview")
+        self.list = PreviewListWidget()
+        self._progress = ProgressWidget(
+            work=self._loadTomograms,
+            yieldCallback=self._onTomogramLoaded,
+        )
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.list, 1)
+        layout.addWidget(self._progress)
+        layout.addStretch(0)
+        self.setLayout(layout)
+
+    def setUri(self, uri: str) -> None:
+        """Sets the URI of the portal that should be used to open preview data."""
+        self._uri = uri
+
+    def load(self, dataset: Dataset) -> None:
+        """Previews the tomograms of the given dataset."""
+        logger.debug("PreviewWidget.load: %s", dataset.id)
+        self.list.clear()
+        self.show()
+        self._progress.submit(dataset)
+
+    def cancel(self) -> None:
+        """Cancels the last dataset preview load."""
+        logger.debug("PreviewWidget.cancel")
+        self._progress.cancel()
+
+    def _loadTomograms(
+        self, dataset: Dataset
+    ) -> Generator[Tuple[Tomogram, np.ndarray], None, None]:
+        logger.debug("PreviewWidget._loadTomograms: %s", dataset.id)
+        client = Client(self._uri)
+        for run in Run.find(client, [Run.dataset_id == dataset.id]):
+            for spacing in run.tomogram_voxel_spacings:
+                for tomogram in spacing.tomograms:
+                    data, _, _ = read_tomogram(tomogram)
+                    # Materialize the lowest resolution level of the zarr for the preview.
+                    data = np.asarray(data[-1])
+                    yield tomogram, data
+
+    def _onTomogramLoaded(self, result: Tuple[Tomogram, np.ndarray]) -> None:
+        tomogram, data = result
+        logger.debug("PreviewWidget._onTomogramLoaded: %s", tomogram.name)
+        icon = _make_tomogram_preview(data)
+        item = QListWidgetItem(icon, tomogram.name)
+        item.setData(Qt.ItemDataRole.UserRole, tomogram)
+        self.list.addItem(item)
+
+
+def _make_tomogram_preview(data: np.ndarray) -> QIcon:
+    depth = data.shape[0]
+    mid_data = np.asarray(data[depth // 2, :, :])
+    preview_data = _normalize_data(mid_data)
+    bitmap = QBitmap.fromData(
+        QSize(*preview_data.shape),
+        preview_data,
+    )
+    return QIcon(bitmap)
+
+
+def _normalize_data(data: np.ndarray) -> np.ndarray:
+    min_data = np.min(data)
+    max_data = np.max(data)
+    range_data = max_data - min_data
+    if range_data == 0:
+        return np.zeros(data.shape, dtype=np.uint8)
+    scaled_data = 255 * (data - min_data) / range_data
+    return scaled_data.astype(np.uint8)

--- a/src/napari_cryoet_data_portal/_widget.py
+++ b/src/napari_cryoet_data_portal/_widget.py
@@ -6,12 +6,13 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from cryoet_data_portal import Client, Tomogram
+from cryoet_data_portal import Tomogram
 
 from napari_cryoet_data_portal._listing_widget import ListingWidget
 from napari_cryoet_data_portal._logging import logger
 from napari_cryoet_data_portal._metadata_widget import MetadataWidget
 from napari_cryoet_data_portal._open_widget import OpenWidget
+from napari_cryoet_data_portal._preview_widget import PreviewWidget
 from napari_cryoet_data_portal._uri_widget import UriWidget
 
 if TYPE_CHECKING:
@@ -44,6 +45,9 @@ class DataPortalWidget(QWidget):
         self._listing = ListingWidget()
         self._listing.hide()
 
+        self._preview = PreviewWidget()
+        self._preview.hide()
+
         self._metadata = MetadataWidget()
         self._metadata.hide()
 
@@ -59,6 +63,7 @@ class DataPortalWidget(QWidget):
         layout = QVBoxLayout()
         layout.addWidget(self._uri)
         layout.addWidget(self._listing, 1)
+        layout.addWidget(self._preview, 1)
         layout.addWidget(self._metadata, 1)
         layout.addWidget(self._open)
         layout.addStretch(0)
@@ -67,12 +72,13 @@ class DataPortalWidget(QWidget):
 
     def _onUriConnected(self, uri: str) -> None:
         logger.debug("DataPortalWidget._onUriConnected")
+        self._preview.setUri(uri)
         self._open.setUri(uri)
         self._listing.load(uri)
 
     def _onUriDisconnected(self) -> None:
         logger.debug("DataPortalWidget._onUriDisconnected")
-        for widget in (self._listing, self._metadata, self._open):
+        for widget in (self._listing, self._preview, self._metadata, self._open):
             widget.cancel()
             widget.hide()
 
@@ -87,8 +93,10 @@ class DataPortalWidget(QWidget):
             self._open.hide()
             return
         data = item.data(0, Qt.ItemDataRole.UserRole)
-        self._metadata.load(data)
+        #self._metadata.load(data)
         if isinstance(data, Tomogram):
             self._open.setTomogram(data)
+            self._preview.hide()
         else:
+            self._preview.load(data)
             self._open.hide()

--- a/src/napari_cryoet_data_portal/_widget.py
+++ b/src/napari_cryoet_data_portal/_widget.py
@@ -2,15 +2,14 @@ from typing import TYPE_CHECKING, Optional
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
+    QListWidgetItem,
     QTreeWidgetItem,
     QVBoxLayout,
     QWidget,
 )
-from cryoet_data_portal import Tomogram
 
 from napari_cryoet_data_portal._listing_widget import ListingWidget
 from napari_cryoet_data_portal._logging import logger
-from napari_cryoet_data_portal._metadata_widget import MetadataWidget
 from napari_cryoet_data_portal._open_widget import OpenWidget
 from napari_cryoet_data_portal._preview_widget import PreviewWidget
 from napari_cryoet_data_portal._uri_widget import UriWidget
@@ -24,7 +23,7 @@ class DataPortalWidget(QWidget):
 
     This consists of a few privately defined sub-widgets, each of which
     has its own task with respect to the data portal like the initial
-    connection or reading metadata from a dataset or tomogram.
+    connection or showing previews of a dataset or tomogram.
     Each task is run asynchronously and can be cancelled.
 
     Examples
@@ -48,9 +47,6 @@ class DataPortalWidget(QWidget):
         self._preview = PreviewWidget()
         self._preview.hide()
 
-        self._metadata = MetadataWidget()
-        self._metadata.hide()
-
         self._open = OpenWidget(napari_viewer)
         self._open.hide()
 
@@ -59,12 +55,14 @@ class DataPortalWidget(QWidget):
         self._listing.tree.currentItemChanged.connect(
             self._onListingItemChanged
         )
+        self._preview.list.currentItemChanged.connect(
+            self._onPreviewItemChanged
+        )
 
         layout = QVBoxLayout()
         layout.addWidget(self._uri)
         layout.addWidget(self._listing, 1)
         layout.addWidget(self._preview, 1)
-        layout.addWidget(self._metadata, 1)
         layout.addWidget(self._open)
         layout.addStretch(0)
 
@@ -78,7 +76,7 @@ class DataPortalWidget(QWidget):
 
     def _onUriDisconnected(self) -> None:
         logger.debug("DataPortalWidget._onUriDisconnected")
-        for widget in (self._listing, self._preview, self._metadata, self._open):
+        for widget in (self._listing, self._preview, self._open):
             widget.cancel()
             widget.hide()
 
@@ -86,17 +84,23 @@ class DataPortalWidget(QWidget):
         self, item: QTreeWidgetItem, old_item: QTreeWidgetItem
     ) -> None:
         logger.debug("DataPortalWidget._onListingItemClicked: %s", item)
+        self._open.hide()
         # The new current item can be none when reconnecting since that
         # clears the listing tree.
         if item is None:
-            self._metadata.hide()
-            self._open.hide()
-            return
-        data = item.data(0, Qt.ItemDataRole.UserRole)
-        #self._metadata.load(data)
-        if isinstance(data, Tomogram):
-            self._open.setTomogram(data)
             self._preview.hide()
         else:
+            data = item.data(0, Qt.ItemDataRole.UserRole)
             self._preview.load(data)
+
+    def _onPreviewItemChanged(
+        self, item: QListWidgetItem, old_item: QListWidgetItem 
+    ) -> None:
+        logger.debug("DataPortalWidget._onPreviewItemChanged: %s", item)
+        # The new current item can be none when reconnecting since that
+        # clears the preview list.
+        if item is None:
             self._open.hide()
+        else:
+            data = item.data(Qt.ItemDataRole.UserRole)
+            self._open.setTomogram(data)


### PR DESCRIPTION
This experiments with showing two separate lists of datasets and tomograms, which allows the portal to be explored more quickly because the datasets can be listed quickly without retrieving any information about the tomograms.

Currently many things are broken, but we can show the preview images for tomograms. We should also consider showing preview images for datasets as on the portal website.

Related to #24