### PR TITLE
[WIP] Fix offset of images at lower resolutions due to non-unit scale

### DIFF
--- a/src/napari_cryoet_data_portal/_sample_data.py
+++ b/src/napari_cryoet_data_portal/_sample_data.py
@@ -30,7 +30,7 @@ def _read_tomogram_from_10000(name: str) -> List[FullLayerData]:
     tomogram_image = read_tomogram(tomogram)
     # Materialize lowest resolution for speed.
     tomogram_image = (np.asarray(tomogram_image[0][-1]), *tomogram_image[1:])
-    tomogram_image[1]["scale"] = tuple(4 * s for s in tomogram_image[1]["scale"])
+    tomogram_image[1]["scale"] = (4, 4, 4)
 
     annotations = tuple(tomogram_spacing.annotations)
     ribosome_annotations = [

--- a/src/napari_cryoet_data_portal/_sample_data.py
+++ b/src/napari_cryoet_data_portal/_sample_data.py
@@ -30,18 +30,18 @@ def _read_tomogram_from_10000(name: str) -> List[FullLayerData]:
     tomogram_image = read_tomogram(tomogram)
     # Materialize lowest resolution for speed.
     tomogram_image = (np.asarray(tomogram_image[0][-1]), *tomogram_image[1:])
-    tomogram_image[1]["scale"] = (4, 4, 4)
+    tomogram_image[1]["scale"] = tuple(4 * s for s in tomogram_image[1]["scale"])
 
     annotations = tuple(tomogram_spacing.annotations)
     ribosome_annotations = [
         item
         for item in annotations
-        if item.object_name.lower() == "cytosolic ribosome"
+        if "cytosolic ribosome" in item.object_name.lower()
     ].pop()
     fas_annotations = [
         item
         for item in annotations
-        if item.object_name.lower() == "fatty acid synthase"
+        if "fatty acid synthase" in item.object_name.lower()
     ].pop()
     ribosome_points = read_annotation(ribosome_annotations, tomogram=tomogram)
     fatty_acid_points = read_annotation(fas_annotations, tomogram=tomogram)

--- a/src/napari_cryoet_data_portal/_tests/test_reader.py
+++ b/src/napari_cryoet_data_portal/_tests/test_reader.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+import numpy as np
 from napari import Viewer
 from napari.layers import Points
 
@@ -22,7 +23,7 @@ def test_read_tomogram_ome_zarr():
     assert data[0].shape == (1000, 928, 960)
     assert data[1].shape == (500, 464, 480)
     assert data[2].shape == (250, 232, 240)
-    assert attrs["scale"] == (1, 1, 1)
+    np.testing.assert_allclose(attrs["scale"], (13.48, 13.48, 13.48), atol=0.01)
     assert layer_type == "image"
 
 


### PR DESCRIPTION
Since the highest/raw resolution tomograms now have a non-unit scale, this caused a bug when visualizing the non-highest/raw resolution tomograms with points annotations due to the way in which we manually offset the tomograms for appropriate display in napari.

This fixes the offset so that it properly takes into account the scale of the tomograms.

Still a WIP, because I need to work out what to do about https://github.com/napari/napari/issues/6914 here.