### PR TITLE
Fix color choice based on object ID

### DIFF
--- a/src/napari_cryoet_data_portal/_reader.py
+++ b/src/napari_cryoet_data_portal/_reader.py
@@ -22,8 +22,11 @@ DEFAULT_OBJECT_COLOR = np.array(OBJECT_COLORMAP(0).rgba)
 
 def _annotation_color(annotation: Annotation) -> np.ndarray:
     """Maps an annotation to a color based on its object_id."""
-    object_id = annotation.object_id.split(":")[-1]
-    color = OBJECT_COLORMAP(hash(object_id) % len(OBJECT_COLORMAP.color_stops))
+    try:
+        object_id = int(annotation.object_id.split(":")[-1])
+    except ValueError as e:
+        object_id = hash(annotation.object_id.split(":")[-1])
+    color = OBJECT_COLORMAP(object_id % len(OBJECT_COLORMAP.color_stops))
     return np.array(color.rgba)
 
 

--- a/src/napari_cryoet_data_portal/_reader.py
+++ b/src/napari_cryoet_data_portal/_reader.py
@@ -22,12 +22,8 @@ DEFAULT_OBJECT_COLOR = np.array(OBJECT_COLORMAP(0).rgba)
 
 def _annotation_color(annotation: Annotation) -> np.ndarray:
     """Maps an annotation to a color based on its object_id."""
-    try:
-        object_id = int(annotation.object_id.split(":")[-1])
-    except RuntimeError as e:
-        logger.error("Failed to parse integer from object_id: %s\%s", annotation.object_id, e)
-        return DEFAULT_OBJECT_COLOR
-    color = OBJECT_COLORMAP(object_id % len(OBJECT_COLORMAP.color_stops))
+    object_id = annotation.object_id.split(":")[-1]
+    color = OBJECT_COLORMAP(hash(object_id) % len(OBJECT_COLORMAP.color_stops))
     return np.array(color.rgba)
 
 


### PR DESCRIPTION
The data portal now also supports UniProtKB accessions as `Annotation.object_id`. UniProtKB accessions can contain letters, so the ID can't be directly converted to an integers anymore. This PR instead uses `hash(Annotation.object_id.split(':')[-1])` to determine consistent colors for annotations of the same objects. 