### PR TITLE
Only rescale points for older napari versions

### DIFF
--- a/src/napari_cryoet_data_portal/_open_widget.py
+++ b/src/napari_cryoet_data_portal/_open_widget.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from functools import cache
+from functools import lru_cache
 from typing import TYPE_CHECKING, Generator, Optional, Tuple
 
 import numpy as np
@@ -210,7 +210,7 @@ def _handle_points_at_scale(
     return data, attrs, layer_type
 
 
-@cache
+@lru_cache(maxsize=None)
 def _is_napari_version_less_than(version: str) -> bool:
     try:
         import napari
@@ -229,8 +229,10 @@ def _is_napari_version_less_than(version: str) -> bool:
             "Failed to parse actual napari version from %s ",
             napari.__version__,
         )
+        return False
     try:
         target_version = Version(version)
     except InvalidVersion:
         logger.warn("Failed to parse target napari version from %s", version)
+        return False
     return actual_version < target_version


### PR DESCRIPTION
napari v0.5 includes a fix to handle expected combinations of point size and layer scale. Previously, we worked around that issue by rescaling the point sizes ourselves. After this PR, we only do that for older versions of napari. The check is cached to avoid spamming the logs.

Alternatively, we could require `napari>=0.5` in `setup.cfg`. I decided to support both versions for now, since v0.5 is quite new and comes with a few of its own new bugs.

This was tested manually by installing v0.4.19 and v0.5.2 of napari and visually inspecting the resulting point sizes.