### PR TITLE
Increase timeouts for tests that open and load data

### DIFF
--- a/src/napari_cryoet_data_portal/_tests/test_open_widget.py
+++ b/src/napari_cryoet_data_portal/_tests/test_open_widget.py
@@ -1,9 +1,8 @@
-from napari.components import ViewerModel
 import pytest
-from pytestqt.qtbot import QtBot
-
 from cryoet_data_portal import Tomogram
+from napari.components import ViewerModel
 from napari.layers import Points
+from pytestqt.qtbot import QtBot
 
 from napari_cryoet_data_portal._open_widget import OpenWidget
 
@@ -27,26 +26,29 @@ def test_init(viewer_model: ViewerModel, qtbot: QtBot):
     assert not widget._progress.isVisibleTo(widget)
 
 
-def test_set_tomogram_adds_layers_to_viewer(widget: OpenWidget, tomogram: Tomogram, qtbot: QtBot):
+def test_set_tomogram_adds_layers_to_viewer(
+    widget: OpenWidget, tomogram: Tomogram, qtbot: QtBot
+):
     assert len(widget._viewer.layers) == 0
     widget._viewer.layers.append(Points())
     assert len(widget._viewer.layers) == 1
     assert widget._clear_existing_layers.isChecked()
-    
-    with qtbot.waitSignal(widget._progress.finished, timeout=30000):
+
+    with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.setTomogram(tomogram)
-    
+
     assert len(widget._viewer.layers) > 1
 
 
-def test_set_tomogram_adds_layers_to_viewer_without_clearing_existing(widget: OpenWidget, tomogram: Tomogram, qtbot: QtBot):
+def test_set_tomogram_adds_layers_to_viewer_without_clearing_existing(
+    widget: OpenWidget, tomogram: Tomogram, qtbot: QtBot
+):
     assert len(widget._viewer.layers) == 0
     widget._viewer.layers.append(Points())
     assert len(widget._viewer.layers) == 1
     widget._clear_existing_layers.setChecked(False)
 
-    with qtbot.waitSignal(widget._progress.finished, timeout=30000):
+    with qtbot.waitSignal(widget._progress.finished, timeout=60000):
         widget.setTomogram(tomogram)
 
     assert len(widget._viewer.layers) > 1
-    


### PR DESCRIPTION
Some tests run against the production API. Some of these have recently been failing by timing out when waiting to open/load tomograms and their annotations. This is occurring on `main` and I'd like to have the tests pass there before creating a new release to address a couple of unrelated bug fixes.

This PR increases timeouts for from 30 to 60 seconds. This is a short term fix that I'm hoping will be good enough.

If we want to support this plugin and its tests in the long term, we should probably set up a fake API for the tests to run against. Or provide a way to filter which tomograms/annotations are opened/loaded and use that in the tests.